### PR TITLE
Create doi_10.21223_P3_DCQB18.R

### DIFF
--- a/scripts/varieties/doi_10.21223_P3_DCQB18.R
+++ b/scripts/varieties/doi_10.21223_P3_DCQB18.R
@@ -1,0 +1,42 @@
+# R script for "carob"
+
+## ISSUES
+# ....
+
+
+carob_script <- function(path) {
+  
+    "The Mother and Baby (M&B) trial methodology was adapted by CIP for Participatory Variety Selection (PVS) through decentralized evaluation networks and multi-year evaluations in potato growing areas in the Andean region. The M&B trial design encourages active participation of farmers through the application of treatments through systematic evaluations and selections of treatments in their own plots called \"Baby trials\" (i.e. farmer managed trials) and in fields with an experimental design called \"Mother trials\" (i.e. researcher managed trials).\r\nObjective: Analyze characteristics, attributes and preferences that men and women have when selecting a new potato variety at the phase of flowering and harvesting.\r\nA M&B trial was performed to evaluate 20 clones with frost resistance at the locality of Chaquicocha, in Pataz province, in La Libertad department, Peru. The trial design was a Randomized Complete Block Design (RCBD) with 2 replicates during 2009. \r\nIn this experiment, characteristics of plant (size, type of foliage) and resistance to diseases during flowering and harvesting were evaluated."
+  
+  uri <- "doi:10.21223/P3/DCQB18"
+  group <- "varieties"
+  ff  <- carobiner::get_data(uri, path, group)
+  
+  meta <- data.frame(
+      carobiner::read_metadata(uri, path, group, major=3, minor=0),
+      data_institute = "CIP",
+      publication = NA,
+      project = NA,
+      data_type = "experiment",
+      treatment_vars = "variety",
+      response_vars = "yield;yield_marketable", 
+      carob_contributor = "Henry Juarez",
+      carob_date = "2024-09-13",
+      notes = NA
+  )
+  
+  process <- carobiner::get_function("process_cip_lbvars", path, group)
+  
+  f <- ff[grep("PTPV", basename(ff))]
+  d <- lapply(f, process, addvars=c("AUDPC","rAUDPC","TTWP"))
+  d <- do.call(rbind, d)
+  
+  carobiner::write_files(path = path,
+                         metadata = meta,
+                         records = d)
+  
+}
+
+## now test your function in a _clean_ R environment (no packages loaded, no other objects available)
+# path <- _____
+# carob_script(path)


### PR DESCRIPTION
Robert. Here's a clean script for participatory varietal selection. 

Regarding the sheet selection logic (_functions.R), I wanted to mention that CIP also handles cases where the sheet is named "F4_Harvest_Mother" (without space). As I understand, the function first checks for "Fieldbook" and reads from it if available, but if not, it reads from "F4_ Harvest_Mother". Can you add and read from "F4_Harvest_Mother" as well.  